### PR TITLE
Setup `BookEntity` to compose a `ReviewCollection`

### DIFF
--- a/src/Book/src/Action/BookAction.php
+++ b/src/Book/src/Action/BookAction.php
@@ -37,13 +37,16 @@ class BookAction implements MiddlewareInterface
         }
 
         $book = $this->book->getBook($id);
+        $book->reviews = $this->review->getReviewsByBook($id);
         $resource = $this->resourceGenerator->fromObject($book, $request);
 
-        $reviews = new HalResource($this->review->getReviewsByBook($id));
-        $author = $author->withLink(
-            new Link('self', '/reviews/' .  $reviews['id'])
-        );
-        $resource = $resource->embed('reviews', [$reviews]);
+        $linkGenerator = $this->resourceGenerator->getLinkGenerator();
+        $resource = $resource->withLink($linkGenerator->templatedFromRoute(
+            'reviews', // link relation
+            $request,
+            'review', // route
+            ['id' => $id] // route parameter subsitutions
+        ));
 
         // $resource = $resource->withLink($this->generateSearchLink(
         //     $this->resourceGenerator->getLinkGenerator(),
@@ -51,6 +54,5 @@ class BookAction implements MiddlewareInterface
         // ));
 
         return $this->responseFactory->createResponse($request, $resource);
-
     }
 }

--- a/src/Book/src/Entity/BookEntity.php
+++ b/src/Book/src/Entity/BookEntity.php
@@ -1,6 +1,8 @@
 <?php
 namespace Book\Entity;
 
+use Book\Collection\ReviewCollection;
+
 class BookEntity
 {
     /**
@@ -27,6 +29,11 @@ class BookEntity
      * @var int Number of book pages.
      */
     public $pages;
+
+    /**
+     * @var ReviewCollection Reviews related to this book.
+     */
+    public $reviews;
 
     /**
      * @var int Year of the book.

--- a/src/Book/src/Model/ReviewModel.php
+++ b/src/Book/src/Model/ReviewModel.php
@@ -37,14 +37,18 @@ class ReviewModel
         return $review;
     }
 
-    public function getReviewsByBook(string $book_id): array
+    public function getReviewsByBook(string $book_id): ReviewCollection
     {
         $statement = $this->pdo->prepare(
             'SELECT * FROM review WHERE book_id = :book_id'
         );
-        $statement->execute([':book_id' => $book_id]);
-        $statement->setFetchMode(PdoService::FETCH_CLASS, ReviewEntity::class);
+        $countStatement = $this->pdo->prepare(
+            'SELECT COUNT(id) FROM review WHERE book_id = :book_id'
+        );
+        $countStatement->bindValue(':book_id', $book_id);
 
-        return $statement->fetchAll();
+        return new ReviewCollection(
+            new PdoPaginator($statement, $countStatement, [], ReviewEntity::class)
+        );
     }
 }


### PR DESCRIPTION
This patch sets up the application to compose a `ReviewCollection` within the `BookEntity`, and thus simplify the middleware for fetching a book resource.

First, it updates `ReviewModel::getReviewsByBook()` to return a `ReviewCollection` instead of an array of `ReviewEntity` instances; this allows the return value to be directly composed in other resources that are passed to the HAL resource generator.

Second, it updates `BookEntity` to add a `$reviews` property, typehinted as a `ReviewCollection`.

Third, it updates `BookAction::process()` to assign the return value of `getReviewsByBook()` directoy to the `$book->reviews` property, prior to calling the resource generator; this allows it to be represented as an embedded collection within the book resource.

Finally, it updates generation of a `reviews` relational link to use the `LinkGenerator` composed in the resource generator.